### PR TITLE
fix: fix set one prop trigger multiple dep func

### DIFF
--- a/reactivity.js
+++ b/reactivity.js
@@ -3,10 +3,19 @@ const targetMap = new WeakMap();
 
 const effect = function (fn) {
   activeEffect = fn;
+
   fn();
+
+  activeEffect = undefined;
 }
 
 const track = function (target, key) {
+  // Only track what caused by calling `effect` directly.
+  // trigger 回放 dep 函数会导致再次执行 get，此时不应该 track
+  if (!activeEffect) {
+    return;
+  }
+
   const dep = targetMap.get(target) || new Map();
   const funcs = dep.get(key) || new Set();
   funcs.add(activeEffect);
@@ -25,6 +34,7 @@ const reactive = function (target) {
   return new Proxy(target, {
     get(target, key, reciever) {
       track(target, key);
+      
       return Reflect.get(target, key, reciever);
     },
     set(target, key, value, reciever) {


### PR DESCRIPTION
https://vuejs.org/guide/extras/reactivity-in-depth.html#how-reactivity-works-in-vue

```js
function whenDepsChange(update) {
  const effect = () => {
    activeEffect = effect
    update()
    activeEffect = null
  }
  effect()
}
```